### PR TITLE
Added logic to prevent wave/enemy duplication if multiple clients present

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -108,6 +108,7 @@ function CreateNPCThread(squad, plyPed)
       SetPedAccuracy(createdNPC, 60)
       SetPedRelationshipGroupHash(createdNPC, GetHashKey("AMBIENT_GANG_WEICHENG"))
       SetPedRelationshipGroupDefaultHash(createdNPC, GetHashKey("AMBIENT_GANG_WEICHENG"))
+      SetPedHasAiBlip(createdNPC, true)
 
       -- set npc relationship with local gang npcs
       for i, ally in pairs(squad.AlliesWith) do

--- a/client.lua
+++ b/client.lua
@@ -3,10 +3,6 @@ IsLocked = false
 ThreadIds = {}
 
 Citizen.CreateThread(function()
-	TriggerServerEvent("checkSpawnedNPCs")
-end)
-
-Citizen.CreateThread(function()
 	while ESX == nil do
 		TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 		Citizen.Wait(0)

--- a/client.lua
+++ b/client.lua
@@ -2,6 +2,14 @@ ESX = nil
 IsLocked = false
 ThreadIds = {}
 
+RegisterNetEvent('npcCheckFromServer')
+AddEventHandler('npcCheckFromServer', function(NPCSpawned)
+	print ("This is spawned from the server")
+	print(NPCSpawned)
+	spawned = NPCSpawned
+end)
+
+
 Citizen.CreateThread(function()
 	while ESX == nil do
 		TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)

--- a/client.lua
+++ b/client.lua
@@ -3,6 +3,10 @@ IsLocked = false
 ThreadIds = {}
 
 Citizen.CreateThread(function()
+	TriggerServerEvent("checkSpawnedNPCs")
+end)
+
+Citizen.CreateThread(function()
 	while ESX == nil do
 		TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 		Citizen.Wait(0)

--- a/client.lua
+++ b/client.lua
@@ -25,6 +25,9 @@ end)
 
 RegisterNetEvent('dispatch:createAOEListener')
 AddEventHandler('dispatch:createAOEListener', function(config)
+if spawned == true then
+print ("NPCs have been spawned")
+else
   for i, squad in pairs(config.DispatchSquads) do
     if config.DebugMode then
       CreateDebugMarker(squad)
@@ -35,18 +38,32 @@ AddEventHandler('dispatch:createAOEListener', function(config)
       Lock = true
       table.insert(ThreadIds, {squad.Name, GetIdOfThisThread()})
       Lock = false
-
+	  TriggerEvent('npcCheckFromServer')
       while true do
         local plyPed = GetPlayerPed(-1)
         local plyPos = GetEntityCoords(plyPed)
         Citizen.Wait(1)
         if ESX.PlayerData.job ~= nil and table.contains( squad.EnemiesWith, ESX.PlayerData.job.name) and (GetVecDist(plyPos, squad.CentralPos) < squad.TriggerDistance) and IsShockingEventInSphere(squad.Event, squad.CentralPos.x, squad.CentralPos.y, squad.CentralPos.z, squad.TriggerDistance) then
-          SpawnEnemyDispatch(squad)
-          Citizen.Wait(squad.TimeBeforeUpAgain)
+		  if spawned == nil then 
+			--print ("BRUH ITS NIL")
+			spawned = false 
+			TriggerServerEvent('spawnCheckHomie', spawned)
+		  elseif spawned == true then
+		  elseif spawned == false then
+			--print ("BRUH ITS FALSE")
+			SpawnEnemyDispatch(squad)
+			spawned = true
+			print(spawned)
+			TriggerServerEvent('spawnCheckHomie', spawned)
+			Citizen.Wait(squad.TimeBeforeUpAgain)
+			spawned = false 
+			TriggerServerEvent('spawnCheckHomie', spawned)
+		   end
         end
       end
     end)
   end
+end
 end)
 
 RegisterNetEvent('dispatch:stopAOEListener')
@@ -93,9 +110,12 @@ function SpawnEnemyDispatch(squad)
     end
     Citizen.Wait(squad.TimeBetweenWaves)
   end
+	spawned = true
+	TriggerServerEvent('spawnCheckHomie', spawned)
 end
 
 function CreateNPCThread(squad, plyPed)
+	TriggerEvent('npcCheckFromServer')
   if table.contains( squad.EnemiesWith, ESX.PlayerData.job.name) then
     Citizen.CreateThread(function()
       Citizen.Wait(0)
@@ -110,7 +130,7 @@ function CreateNPCThread(squad, plyPed)
 
       -- Randomly spawn in npc
       Citizen.Wait(math.random(1000, 2000))
-      local createdNPC = CreatePed(4, npc, spawnPoint.x, spawnPoint.y, spawnPoint.z, spawnPoint.h, true, false)
+      local createdNPC = CreatePed(4, npc, spawnPoint.x, spawnPoint.y, spawnPoint.z, spawnPoint.h, true, true)
       SetNetworkIdExistsOnAllMachines(NetworkGetNetworkIdFromEntity(createdNPC), true)
 
       SetPedAccuracy(createdNPC, 60)
@@ -186,6 +206,8 @@ function CreateNPCThread(squad, plyPed)
       DeleteNPC(createdNPC)
     end)
   end
+	spawned = true
+	TriggerServerEvent('spawnCheckHomie', spawned)
 end
 
 function DeleteNPC(entity)

--- a/example/config.lua
+++ b/example/config.lua
@@ -14,7 +14,8 @@ Config.DispatchSquads = {
             'mechanic',
             'taxi'
         },
-        Event = 89, -- number cooresponts to https://runtime.fivem.net/doc/natives/?_0x1374ABB7C15BAB92
+        Event = 91, -- number corresponds to https://runtime.fivem.net/doc/natives/?_0x1374ABB7C15BAB92 |Change it to 91 for Gamebuild 2372 | Trigger when shooting
+      --Event = 89, -- Use this if you are on a Gamebuild earlier than 2372
         NumberOfWaves = 3,
         NumberPerWave = 2,
         TimeBetweenWaves = math.random(5000, 8000), -- in ms
@@ -63,7 +64,8 @@ Config.DispatchSquads = {
             'mechanic',
             'taxi'
         },
-        Event = 89,
+        Event = 91, -- number corresponds to https://runtime.fivem.net/doc/natives/?_0x1374ABB7C15BAB92 |Change it to 91 for Gamebuild 2372 | Trigger when shooting
+      --Event = 89, -- Use this if you are on a Gamebuild earlier than 2372
         NumberOfWaves = 3,
         NumberPerWave = 2,
         TimeBetweenWaves = math.random(5000, 8000), -- in ms

--- a/server.lua
+++ b/server.lua
@@ -5,6 +5,7 @@ AddEventHandler('dispatch:createDispatch', function(config)
             if not NPCSHaveSpawned then
                 NPCSHaveSpawned = true
                 TriggerClientEvent("dispatch:createAOEListener", -1, config)
+            end
 end)
 
 RegisterServerEvent('dispatch:stopDispatch')

--- a/server.lua
+++ b/server.lua
@@ -1,6 +1,9 @@
+
 RegisterServerEvent('dispatch:createDispatch')
 AddEventHandler('dispatch:createDispatch', function(config)
-    TriggerClientEvent("dispatch:createAOEListener", -1, config)
+            if not NPCSHaveSpawned then
+                NPCSHaveSpawned = true
+                TriggerClientEvent("dispatch:createAOEListener", -1, config)
 end)
 
 RegisterServerEvent('dispatch:stopDispatch')

--- a/server.lua
+++ b/server.lua
@@ -1,11 +1,16 @@
-local NPCSHaveSpawned = false
+RegisterServerEvent('spawnCheckHomie')
+	AddEventHandler('spawnCheckHomie', function(spawned)
+		NPCSpawned = spawned
+		print ("This is spawned coming from the client")
+		print(spawned)
+		--TriggerEvent('PassBackToClient', isSpawned)
+		TriggerClientEvent('npcCheckFromServer', NPCSpawned)
+	
+end)
 
 RegisterServerEvent('dispatch:createDispatch')
 AddEventHandler('dispatch:createDispatch', function(config)
-            if not NPCSHaveSpawned then
-                NPCSHaveSpawned = true
                 TriggerClientEvent("dispatch:createAOEListener", -1, config)
-            end
 end)
 
 RegisterServerEvent('dispatch:stopDispatch')

--- a/server.lua
+++ b/server.lua
@@ -1,3 +1,4 @@
+local NPCSHaveSpawned = false
 
 RegisterServerEvent('dispatch:createDispatch')
 AddEventHandler('dispatch:createDispatch', function(config)


### PR DESCRIPTION
This is a really basic attempt at creating a logic to prevent the problem of enemies and waves multiplying by the number of people that are around.
What it does is create a client and server event which pass a variable back and forth.
Once the server gives the client the variable "NPCSpawned" set to true, the client should no longer attempt to spawn peds.

I've tested this with a friend and it seems to work. (Before this, it'd spawn in 12 peds, now it only spawned in 6, how it should, with two of us present).

@Henry12116 if you can, give this a quick look and check if anything seems off and please test it as well.
